### PR TITLE
 On Record Creation Lookup Fix : Schema is used instead of logical name

### DIFF
--- a/CRMRESTBuilder/scripts/Xrm.RESTBuilder.js
+++ b/CRMRESTBuilder/scripts/Xrm.RESTBuilder.js
@@ -3796,7 +3796,7 @@ Xrm.RESTBuilder.BuildObjectString_WebApi = function () {
 		if (field.length === 0) {
 			continue;
 		}
-		var logical = field[0].LogicalName;
+		var logical = field[0].SchemaName;
 		var val1 = $(tr).find("input:first").val();
 		var sel1 = $(tr).find("select:eq(1)").val();
 


### PR DESCRIPTION
The issue occurs when lookup field created using Letter Case and example is given below:
Display Name: Builder Id
Logical Name: new_builderid
Schema Name: new_BuilderId

Thanks.
